### PR TITLE
removed threading, it's causing pip installation failure

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -75,4 +75,3 @@ urllib3==2.4.0
 watchdog==6.0.0
 websockets==15.0.1
 Werkzeug==3.1.3
-threading


### PR DESCRIPTION
threading is not a package so it's causing installation failure. (creating a pull req for changing 1 line Lmao)